### PR TITLE
Some fixes for our codeActions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                     "default": "",
                     "description": "Prefix for generated private member declarations"
                 },
+                "csharpextensions.useThisForCtorAssignments": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Wether or not a ctor assignment of a property or variable should be prefixed with this."
+                },
                 "csharpextensions.reFormatAfterChange": {
                     "type": "boolean",
                     "default": true,

--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -227,13 +227,14 @@ export default class CodeActionProvider implements vscode.CodeActionProvider{
         
         var tabSize = vscode.workspace.getConfiguration().get('editor.tabSize', 4);
         var privateMemberPrefix = vscode.workspace.getConfiguration().get('csharpextensions.privateMemberPrefix', '');
-
+        var prefixWithThis = vscode.workspace.getConfiguration().get('csharpextensions.useThisForCtorAssignments', true);
+        
         var parameter:InitializeFieldFromConstructor = {
             document: document,            
             type: parameterType,
             name: selectedName,
             privateDeclaration: `${Array(tabSize*2).join(' ')} private readonly ${parameterType} ${privateMemberPrefix}${selectedName};\r\n`,
-            memberInitialization: `${Array(tabSize*3).join(' ')} this.${privateMemberPrefix}${selectedName} = ${selectedName};\r\n`,
+            memberInitialization: `${Array(tabSize*3).join(' ')} ${(prefixWithThis?'this.':'')}${privateMemberPrefix}${selectedName} = ${selectedName};\r\n`,
             constructorBodyStart: this.findConstructorBodyStart(document,position),
             constructorStart: this.findConstructorStart(document,position)
         };        

--- a/src/codeActionProvider.ts
+++ b/src/codeActionProvider.ts
@@ -22,8 +22,9 @@ export default class CodeActionProvider implements vscode.CodeActionProvider{
         
         var ctorPCommand = this.getCtorpCommand(document, range, context, token);
         if(ctorPCommand)
-            commands.push(ctorPCommand);
+            commands.push(ctorPCommand);                
 
+        
         return commands;  
     }
 
@@ -202,7 +203,7 @@ export default class CodeActionProvider implements vscode.CodeActionProvider{
         if(!wordRange)
             return null;
 
-        var regex = new RegExp(/(public|private|protected)\s(.*)\(([\s\S]*?)\)/gi);
+        var regex = new RegExp(/(public|private|protected)\s(.*?)\(([\s\S]*?)\)/gi);
         var matches = regex.exec(surrounding);
         if(!matches)
             return null;


### PR DESCRIPTION
Adressing issue https://github.com/jchannon/csharpextensions/issues/14
Adds a setting for wether or not private member assignments in ctor generated by 'Initialize from ctor' is prefixed with 'this.'.